### PR TITLE
Update makefile to use local cabal installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ configure:
 
 .PHONY:
 parser:
-	happy src/Parser.y
+	cabal run happy src/Parser.y
 
 .PHONY:
 tokenizer:
-	alex src/Tokenizer.x
+	cabal run alex src/Tokenizer.x
 
 build: tokenizer parser configure
 	cabal build


### PR DESCRIPTION
The previous versions needed alex and happy to be installed globally.
Now they are run from the sandbox.