### PR TITLE
Remove "Move to separate file" instruction

### DIFF
--- a/src/Generator.hs
+++ b/src/Generator.hs
@@ -96,9 +96,6 @@ generateExpression (ExpressionItem item) = do
       emitInstruction $ TwoIR reg (C constant) False
       return reg
 
------------------------------------------------
--- Move the functions below to separate file --
------------------------------------------------
 
 getRegister :: State CodeGenState IRItem
 getRegister = do


### PR DESCRIPTION
The generator file had an instruction that some functions should be
moved to a separate file. However after discussion an agreement was made
that these files should stay where they are. They are so tightly coupled
with the functions over that separating them doens't make sense.