### PR TITLE
Add list of pre-compiled modules to other-modules

### DIFF
--- a/hdc.cabal
+++ b/hdc.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.8
 
 executable hdc
   main-is:             Main.hs
-  -- other-modules:
   build-depends:       base ==4.*, array ==0.*, pretty-show, ghc, containers, mtl, MissingH, regex-posix
   hs-source-dirs:      src
   build-tools:         alex, happy
+  other-modules:       Parser, Tokenizer


### PR DESCRIPTION
This fixes cabal refusing to build hdc, due to some arcane reasons.
Solved thanks to
http://stackoverflow.com/questions/4465666/using-alex-happy-with-cabal
which doesn't exactly explain why things break, but it does fix the
problem.