### PR TITLE
Assembler module

### DIFF
--- a/src/Assembler.hs
+++ b/src/Assembler.hs
@@ -1,0 +1,42 @@
+module Assembler(assemble) where
+
+import Datatypes
+import Opcodes
+
+assemble :: [IR] -> [Int]
+assemble instructions = (map assembleInstruction instructions)
+
+assembleInstruction :: IR -> Int
+
+assembleInstruction LoadIR = (hexOpcode Lw)
+
+assembleInstruction StoreIR = (hexOpcode Sw)
+
+assembleInstruction (TwoIR (R reg) (I immediate)  masked) =
+  (hexMask masked) + (hexOpcode Addi) + (hexRt reg) + (immediate `mod` 2**16)
+
+assembleInstruction (TwoIR (R reg) (C address) masked) =
+  (hexMask masked) + (hexOpcode Ldc) + (hexRt reg) + (address `mod` 2**16)
+
+assembleInstruction (ThreeIR operator (R rd) (R rs) (R rt) masked) =
+  (hexMask masked) + (hexOpcode opcode) + (hexRd rd) + (hexRs rs) + (hexRt rt) + (hexAlufunction opcode)
+    where opcode = case operator of
+                BitwiseAnd -> And
+                BitwiseOr -> Or
+                BitwiseXor -> Xor
+                Plus -> Add
+                Minus -> Sub
+                Multiply -> Mul
+                LessThan -> Slt
+                EqualTo -> Seq
+
+assembleInstruction (ThreeIR op rd (I rs) (R rt) masked)
+  | op == Plus = assembleInstruction (ThreeIR op rd (R rt) (I rs) masked)
+
+assembleInstruction (ThreeIR operator (R rd) (R rs) (I sh) masked) =
+  (hexMask masked) + (hexOpcode opcode) + (hexRd rd) + (hexRs rs) + sh
+  where opcode = case operator of
+               Plus -> Addi
+               ShiftLeft -> Sll
+               ShiftRight -> Srl
+               ShiftRightArithmetic -> Sra

--- a/src/Opcodes.hs
+++ b/src/Opcodes.hs
@@ -1,6 +1,7 @@
 module Opcodes where
 
 import Data.Char (toLower)
+import Data.Bits
 
 data Opcode = And
             | Or
@@ -14,7 +15,55 @@ data Opcode = And
             | Sll
             | Srl
             | Sra
+            | Ldc
+            | Lw
+            | Sw
+            | ThreadFinished
     deriving (Show, Eq)
 
 mnemonic :: Opcode -> String
 mnemonic = map toLower . show
+
+hexOpcode :: Opcode -> Int
+hexOpcode opcode =
+  code `shiftL` 26
+  where code = opcode of
+     Ldc            -> 0x2
+     Addi           -> 0x1
+     Lw             -> 0x8
+     Sw             -> 0x4
+     ThreadFinished -> 0x10
+     _              -> 0x0
+
+hexAlufunction :: Opcode -> Int
+hexAlufunction opcode =
+  case opcode of
+    Add ->  0x4
+    Sub ->  0x4
+    Mul ->  0x9
+    And ->  0x6
+    Or  ->  0x7
+    Xor ->  0x8
+    Slt ->  0x3
+    Seq ->  0xA
+    Sll ->  0x0
+    Srl ->  0x1
+    Sra ->  0x2
+    _   ->  0x0
+
+hexRs :: Int -> Int
+hexRs rs =
+  rs `shiftL` 21
+
+hexRt :: Int -> Int
+hexRt rt =
+  rt `shiftL` 16
+
+hexRd :: Int -> Int
+hexRd rd =
+  rd `shiftL` 11
+
+hexMask :: Bool -> Int
+hexMask mask
+  | mask      = 1 `shiftL` 31
+  | otherwise = 0


### PR DESCRIPTION
This prq adds the assembler module. This module has all the functions needed to be able to assemble the IR to hex code. What is not included here is the part needed to connect this to the rest of the main module.

This is an iteration on #20 .